### PR TITLE
chore: v0.1.0 release prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,135 @@
+name: Release & Publish
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (skip actual publish)"
+        type: boolean
+        default: true
+
+jobs:
+  validate:
+    name: Validate Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check version matches tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION=$(node -p "require('./packages/interoception/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "❌ Version mismatch!"
+            echo "   Tag: v$TAG_VERSION"
+            echo "   package.json: $PKG_VERSION"
+            exit 1
+          fi
+          echo "✅ Version match: $TAG_VERSION"
+
+      - name: Check CHANGELOG has entry
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          if ! grep -q "## \[$TAG_VERSION\]" CHANGELOG.md; then
+            echo "❌ No CHANGELOG entry for v$TAG_VERSION"
+            exit 1
+          fi
+          echo "✅ CHANGELOG entry found"
+
+  build:
+    name: Build & Test
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: packages/interoception/dist/
+
+  publish-npm:
+    name: Publish to npm
+    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@peleke.s/interoception
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: packages/interoception/dist/
+
+      - name: Publish to npm
+        working-directory: packages/interoception
+        run: pnpm publish --provenance --access public --no-git-checks
+
+  github-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          NOTES=$(awk "/^## \[$TAG_VERSION\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --notes "${{ steps.changelog.outputs.notes }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] — 2026-02-05
+
+### Features
+
+- **Pre-execution coherence sensor** — `createPreExecSensor` orchestrates the full sensing pipeline
+- **Four built-in metrics** — goal drift, memory retention, contradiction pressure, semantic diffusion
+- **MetricFn strategy pattern** — swap, add, or replace metrics via pluggable interface
+- **ScalarMetricFn** — async scalar metrics that read directly from agent state (no embeddings)
+- **Metric polarity** — `inverted` flag on MetricFn/ScalarMetricFn declares whether higher = less coherent
+- **Coherence index** — weighted aggregation with configurable `invertedMetrics` parameter
+- **Band classification** — green/yellow/orange/red with configurable thresholds
+- **Pluggable interfaces** — `Embedder` and `StateProvider` (consumer implements)
+- **Vector utilities** — `cosineSimilarity`, `dot`, `magnitude`, `normalize`, `mean`, `clamp01`
+- **History ring buffer** — configurable size, newest-first retrieval
+- **Re-exports `Tick`** from `@peleke.s/cadence` for convenience
+
+### Testing
+
+- 105 tests: unit + integration + property (fast-check) + metamorphic
+- Backwards compatibility verified across all changes

--- a/docs/guides/coherence-index.md
+++ b/docs/guides/coherence-index.md
@@ -17,7 +17,9 @@ const metrics = {
   semanticDiffusion: 0.15,
 };
 
-const index = computeCoherenceIndex(metrics);
+const invertedMetrics = new Set(["goalDrift", "contradictionPressure", "semanticDiffusion"]);
+
+const index = computeCoherenceIndex(metrics, undefined, invertedMetrics);
 const band = classifyBand(index);
 
 console.log(index); // ~0.86
@@ -33,7 +35,7 @@ Metrics have different polarities:
 - **Not inverted** (e.g., `memoryRetention`): higher value = more coherent → used as-is
 - **Inverted** (e.g., `goalDrift`): higher value = less coherent → flipped to `1 - value`
 
-The function maintains a hardcoded set of inverted metrics: `goalDrift`, `contradictionPressure`, and `semanticDiffusion`. Memory retention is the only core metric that's used directly (higher = better).
+The sensor builds the inverted set automatically from each metric's `inverted` flag. When calling `computeCoherenceIndex` directly, you pass the inverted set as the third parameter (defaults to empty set).
 
 ### Weighted Sum
 
@@ -130,6 +132,7 @@ classifyBand(0.35); // "red"
 function computeCoherenceIndex(
   metrics: MetricSnapshot,
   weights?: MetricWeights,
+  invertedMetrics?: ReadonlySet<string>,
 ): number;
 
 function classifyBand(

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -14,7 +14,7 @@ Method: for each context embedding, find its max cosine similarity to any goal e
 |----------|-------|
 | Name | `goalDrift` |
 | Range | 0 (aligned) to 1 (drifted) |
-| Polarity | Higher = less coherent (inverted during index computation) |
+| Inverted | Yes — higher = less coherent |
 
 ```typescript
 import { computeGoalDrift, goalDriftMetric } from "@peleke.s/interoception";
@@ -38,7 +38,7 @@ Method: for each goal embedding, find its max cosine similarity to any goal-rele
 |----------|-------|
 | Name | `memoryRetention` |
 | Range | 0 (forgotten) to 1 (retained) |
-| Polarity | Higher = more coherent (used directly) |
+| Inverted | No — higher = more coherent |
 
 ```typescript
 import { computeMemoryRetention, memoryRetentionMetric } from "@peleke.s/interoception";
@@ -56,7 +56,7 @@ Method: pairwise cosine similarity across context embeddings. Count pairs below 
 |----------|-------|
 | Name | `contradictionPressure` |
 | Range | 0 (coherent) to 1 (contradictory) |
-| Polarity | Higher = less coherent (inverted during index computation) |
+| Inverted | Yes — higher = less coherent |
 
 ```typescript
 import { computeContradictionPressure, contradictionPressureMetric } from "@peleke.s/interoception";
@@ -78,7 +78,7 @@ Method: mean pairwise distance (`1 - cosineSimilarity`) across context embedding
 |----------|-------|
 | Name | `semanticDiffusion` |
 | Range | 0 (focused) to 1 (diffuse) |
-| Polarity | Higher = less coherent (inverted during index computation) |
+| Inverted | Yes — higher = less coherent |
 
 ```typescript
 import { computeSemanticDiffusion, semanticDiffusionMetric } from "@peleke.s/interoception";
@@ -100,6 +100,7 @@ This ensures the sensor never throws on edge cases.
 ```typescript
 interface MetricFn {
   name: string;
+  inverted?: boolean;
   compute(input: MetricInput): number;
 }
 ```
@@ -122,6 +123,7 @@ import type { MetricFn } from "@peleke.s/interoception";
 
 const focusScore: MetricFn = {
   name: "focusScore",
+  inverted: false, // Higher = more focused = more coherent
   compute(input) {
     // Custom logic using input.goalEmbeddings, contextEmbeddings, etc.
     return 0.8;
@@ -132,11 +134,34 @@ const focusScore: MetricFn = {
 Rules for custom metrics:
 
 1. Return a value in [0, 1]
-2. Return 0 when inputs are empty (noop-safe)
-3. The `name` becomes the key in `MetricSnapshot`
+2. Set `inverted: true` if higher values mean less coherent
+3. Return 0 when inputs are empty (noop-safe)
+4. The `name` becomes the key in `MetricSnapshot`
 
-!!! note
-    Custom metrics with "higher = worse" polarity are handled by `computeCoherenceIndex`, which maintains an internal set of inverted metric names (`goalDrift`, `contradictionPressure`, `semanticDiffusion`). If you add custom metrics that need inversion, you'll need to either pre-invert them or provide custom weights accordingly.
+## ScalarMetricFn Interface
+
+```typescript
+interface ScalarMetricFn {
+  name: string;
+  inverted?: boolean;
+  compute(): number | Promise<number>;
+}
+```
+
+Scalar metrics don't receive embedding data. They close over their own dependencies at construction time and read directly from agent state, databases, APIs, etc.
+
+```typescript
+import type { ScalarMetricFn } from "@peleke.s/interoception";
+
+const responseLatency: ScalarMetricFn = {
+  name: "responseLatency",
+  inverted: true, // High latency = less coherent
+  async compute() {
+    const latency = await getAverageLatency();
+    return Math.min(latency / 5000, 1); // Normalize to [0, 1]
+  },
+};
+```
 
 ## Default Metrics
 

--- a/docs/reference/exports.md
+++ b/docs/reference/exports.md
@@ -45,7 +45,7 @@ import {
 | `computeMemoryRetention(goalEmbeddings, memoryEmbeddings)` | metrics | Compute memory retention score |
 | `computeContradictionPressure(contextEmbeddings, threshold?)` | metrics | Compute contradiction pressure |
 | `computeSemanticDiffusion(contextEmbeddings)` | metrics | Compute semantic diffusion |
-| `computeCoherenceIndex(metrics, weights?)` | metrics | Compute weighted coherence index |
+| `computeCoherenceIndex(metrics, weights?, invertedMetrics?)` | metrics | Compute weighted coherence index |
 | `classifyBand(coherenceIndex, thresholds?)` | metrics | Classify index into a band |
 | `cosineSimilarity(a, b)` | util | Cosine similarity between vectors |
 | `dot(a, b)` | util | Dot product of two vectors |
@@ -64,12 +64,12 @@ import {
 
 ## Metric Instances
 
-| Instance | Type | Description |
-|----------|------|-------------|
-| `goalDriftMetric` | `MetricFn` | Goal drift as a pluggable metric |
-| `memoryRetentionMetric` | `MetricFn` | Memory retention as a pluggable metric |
-| `contradictionPressureMetric` | `MetricFn` | Contradiction pressure as a pluggable metric |
-| `semanticDiffusionMetric` | `MetricFn` | Semantic diffusion as a pluggable metric |
+| Instance | Type | Inverted | Description |
+|----------|------|----------|-------------|
+| `goalDriftMetric` | `MetricFn` | Yes | Goal drift as a pluggable metric |
+| `memoryRetentionMetric` | `MetricFn` | No | Memory retention as a pluggable metric |
+| `contradictionPressureMetric` | `MetricFn` | Yes | Contradiction pressure as a pluggable metric |
+| `semanticDiffusionMetric` | `MetricFn` | Yes | Semantic diffusion as a pluggable metric |
 
 ## Types
 
@@ -77,7 +77,8 @@ import {
 |------|--------|-------------|
 | `Embedder` | types | Pluggable embedding interface |
 | `StateProvider` | types | Pluggable agent state access |
-| `MetricFn` | types | Metric strategy pattern |
+| `MetricFn` | types | Embedding-based metric strategy |
+| `ScalarMetricFn` | types | Scalar metric strategy (no embeddings) |
 | `MetricInput` | types | Input data for metric functions |
 | `MetricSnapshot` | types | All metric values |
 | `MetricWeights` | types | Weights for coherence index |

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -53,6 +53,7 @@ A single metric function. Strategy pattern — consumers can swap, add, or repla
 ```typescript
 interface MetricFn {
   name: string;
+  inverted?: boolean;
   compute(input: MetricInput): number;
 }
 ```
@@ -60,7 +61,28 @@ interface MetricFn {
 | Property | Type | Description |
 |----------|------|-------------|
 | `name` | `string` | Metric name, used as key in `MetricSnapshot` |
+| `inverted` | `boolean \| undefined` | If true, higher values = less coherent |
 | `compute` | `(input: MetricInput) => number` | Compute metric value in [0, 1] |
+
+**Used by:** [`PreExecSensorOptions`](#preexecsensoroptions)
+
+### `ScalarMetricFn`
+
+A scalar metric that reads directly from agent state (no embeddings). Async-capable, noop-safe (return 0 if data unavailable).
+
+```typescript
+interface ScalarMetricFn {
+  name: string;
+  inverted?: boolean;
+  compute(): number | Promise<number>;
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | `string` | Metric name, used as key in `MetricSnapshot` |
+| `inverted` | `boolean \| undefined` | If true, higher values = less coherent |
+| `compute` | `() => number \| Promise<number>` | Compute metric value in [0, 1] |
 
 **Used by:** [`PreExecSensorOptions`](#preexecsensoroptions)
 
@@ -211,6 +233,7 @@ interface PreExecSensorOptions {
   embedder: Embedder;
   state: StateProvider;
   metrics?: MetricFn[];
+  scalarMetrics?: ScalarMetricFn[];
   weights?: MetricWeights;
   thresholds?: BandThresholds;
   onReading?: (reading: CoherenceReading) => void | Promise<void>;
@@ -222,7 +245,8 @@ interface PreExecSensorOptions {
 |----------|------|---------|-------------|
 | `embedder` | `Embedder` | — | Embedding provider |
 | `state` | `StateProvider` | — | Agent state provider |
-| `metrics` | `MetricFn[]` | `DEFAULT_METRICS` | Metric functions to run |
+| `metrics` | `MetricFn[]` | `DEFAULT_METRICS` | Embedding-based metrics |
+| `scalarMetrics` | `ScalarMetricFn[]` | `[]` | Scalar metrics (no embeddings) |
 | `weights` | `MetricWeights` | `DEFAULT_WEIGHTS` | Coherence index weights |
 | `thresholds` | `BandThresholds` | `DEFAULT_THRESHOLDS` | Band thresholds |
 | `onReading` | `(reading: CoherenceReading) => void \| Promise<void>` | — | Post-reading callback |

--- a/packages/interoception/package.json
+++ b/packages/interoception/package.json
@@ -17,7 +17,9 @@
   "scripts": {
     "build": "tsup",
     "test": "vitest --run",
-    "lint": "oxlint src"
+    "test:coverage": "vitest --run --coverage",
+    "lint": "oxlint src",
+    "prepublishOnly": "pnpm build"
   },
   "keywords": [
     "coherence",


### PR DESCRIPTION
## Summary

- Add CI workflow (lint, build, test) for push to main + PRs
- Add publish workflow (npm publish with provenance on `v*` tag push)
- Update docs for PR #3 features (ScalarMetricFn, `inverted` flag, 3-param `computeCoherenceIndex`)
- Add `CHANGELOG.md` with v0.1.0 entry
- Add `prepublishOnly` and `test:coverage` scripts to package.json

Closes #9

## Test plan

- [x] 105 tests pass
- [x] `mkdocs build --strict` passes
- [ ] CI workflow runs on PR
- [ ] After merge: tag `v0.1.0`, publish manually, verify workflow for future releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)